### PR TITLE
Downgrade to node 18.x.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 18.x
 
       - name: Install MyST Markdown
         run: npm install -g mystmd


### PR DESCRIPTION
I'm wondering if the deploy errors are due to how artifacts are being generated.