### PR TITLE
Add info about targetpath required to launch Shiny application

### DIFF
--- a/technology/shiny.md
+++ b/technology/shiny.md
@@ -37,7 +37,7 @@ https://datahub.berkeley.edu/hub/user-redirect/git-pull?repo=<repository-url>&br
 Here is an example link that launches Shiny application in R-staging hub,
 
 ```bash
-https://r-staging.datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fds-modules%2Fpolisci-3&branch=main&urlpath=shiny%2Fpolisci-3%2FModule_8_Regression%2F&targetPath=ShinyApps/polisci-3
+https://r.datahub.berkeley.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fds-modules%2Fpolisci-3&branch=main&urlpath=shiny%2Fpolisci-3%2FModule_8_Regression%2F&targetPath=ShinyApps/polisci-3
 ```
 
 Users can also run Shiny from the JupyterLab launcher. This will display a shiny file browser.


### PR DESCRIPTION
- Adds information about `targetpath` url parameter
- Provides examples to help users construct nbgitpuller links