### PR TITLE
Restricted Hub Documentation

### DIFF
--- a/workflows/logging-in.md
+++ b/workflows/logging-in.md
@@ -7,22 +7,35 @@ for authentication. The hubs not using bCourses are edx, highschool, and worksho
 
 ## Authorization
 
-Anyone who can log in to bCourses can log into our hubs. This includes all
-Berkeley affiliates. This means if you have a working berkeley.edu email
-account, you can most likely log in to our JupyterHubs.
+Authentication takes place via bCourses. In order to log into a hub, you must be 
+able to log into bCourses. If you have a working berkeley.edu email account,
+you can most likely log in to our JupyterHubs. 
 
-Students have access for 9 months after they graduate. If they have
-an incomplete, they have 13 months of access instead.
+After graduation, students have access for 9 months. If a student has an incomplete,
+they have 13 months of access.
+
+In Summer 2025, we piloted restricting access for certain course-specific hubs. In order to
+access a restricted hub, one must be on the bCourses roster for the current or previous semester.
+
+This pilot will expand in Fall 2025 to include Data 8, Data 100, Data 101, Data 102, Stat 20,
+and Stat 159's hubs. Gating access to course specific hubs will ensure that only students who
+are enrolled in a course have access to the course specific resources on each hub and reduce 
+costs. There is no plan to restrict access to the [general datahub](https://datahub.berkeley.edu/);
+If you have access to bCourses, you will have access to the general datahub.
 
 ## Non-Berkeley affiliates
 
 If someone who doesn't have a berkeley.edu account wants to use
 the hubs, they need to obtain a [CalNet Sponsored Guest
-account](https://calnetweb.berkeley.edu/calnet-departments/calnet-sponsored-guests) and get added to a bCourses course.
+account](https://calnetweb.berkeley.edu/calnet-departments/calnet-sponsored-guests) and be added to a bCourses course.
 
 ## bCourses and Groups
 
 bCourses knows which courses that students and course staff are affiliated with, as well as which [ad hoc groups](https://community.canvaslms.com/t5/Instructor-Guide/How-do-I-manually-assign-students-to-groups/ta-p/663) that people have been assigned to by course staff. This information is communicated to the hubs when people login, which can be useful for [elevating the privileges](admin#obtaining-elevated-privileges) of some users or granting additional computing resources to others.
+
+If you are an instructor for a course with a restricted access hub, you can add someone who is not enrolled in the course as an [observer](https://community.canvaslms.com/t5/Canvas-Basics-Guide/What-is-the-Observer-role/ta-p/4) in bCourses to grant them access to the hub. 
+
+All students who are enrolled in a course with a restricted hub will have access to the hub during the semester they are enrolled in the course and the following semester as long as they remain on the bCourses roster. You may find that students with unique enrollment situations (e.g. a high school student enrolled during a summer session or a student finishing the course after taking an incomplete) may not have access to a restricted hub if they are unenrolled from the courses's bCourses. Additionally, students who drop a course associated with a restricted hub will be removed from the bCourses roster and lose access to the restricted hub within 24 hours. If a student has trouble accessing a restricted hub, first ensure that the student is on the bCourses roster for either the previous or the current semester. If a student is not on the roster, instructors should add the student to the appropriate bCourses roster with the role of "Student."
 
 ## Troubleshooting
 


### PR DESCRIPTION
I included the names of courses that will have restricted hubs in Fall 2025. I believe that we should publicly maintain a list of hubs with restricted access to reduce confusion. I understand if the curriculum guide isn't the right place for it, just let me know @balajialg 